### PR TITLE
Fix sabre/vobject in composer.json was missing for calendar plugin

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,7 @@ CHANGELOG Roundcube Webmail
 - Fix in the domain part. Punicode domains did not work
 - Added ContextMenu 2.2 (2017-01-02)
 - Added Kolab calendar 3.2.16
+- Fix sabre/vobject in composer.json was missing for calendar plugin
 
 RELEASE 1.3-beta
 ----------------

--- a/composer.json-dist
+++ b/composer.json-dist
@@ -31,10 +31,12 @@
         "pear-pear.php.net/net_smtp": "~1.7.1",
         "pear-pear.php.net/crypt_gpg": "~1.6.0@beta",
         "roundcube/net_sieve": "~1.5.0",
+		"sabre/vobject": "~3.3.3",
         "endroid/qrcode": "~1.6.5"
     },
     "require-dev": {
-        "phpunit/phpunit": "*"
+        "phpunit/phpunit": "*",
+		"pear/auth_sasl": "dev-master"
     },
     "suggest": {
         "pear-pear.php.net/net_ldap2": "~2.2.0 required for connecting to LDAP address books",


### PR DESCRIPTION
Fix sabre/vobject in composer.json was missing for calendar plugin