### PR TITLE
Add note about install-jsdeps.sh to upgrade procedure/ Fix double http request regression (#5633)

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -41,15 +41,18 @@ it on a unix system, you need to do the following operations by hand:
    ./skins/
    ./plugins/
    ./vendor/
+4. Update dependencies:
 4a. If you previously installed plugins through composer, update dependencies
-   by running `php composer.phar update --no-dev`
+   by running `php composer.phar update --no-dev`.
 4b. Install/update dependencies using composer:
    - get composer from https://getcomposer.org/download/
    - rename the composer.json-dist file into composer.json
    - if you want to use LDAP address books, enable the LDAP libraries in your
      composer.json file by moving the items from "suggest" to the "require"
      section (remove the explanation texts after the version!).
-   - run `php composer.phar install --no-dev`
+   - run `php composer.phar install --no-dev`.
+4c. If you use git sources or the release package without dependencies
+   update javascript dependencies by executing `bin/install-jsdeps.sh` script.
 5. Run `./bin/update.sh` from the commandline OR
    open http://url-to-roundcube/installer/ in a browser and choose "3 Test config".
    To enable the latter one, you have to temporary set 'enable_installer'

--- a/program/js/app.js
+++ b/program/js/app.js
@@ -230,7 +230,6 @@ function rcube_webmail()
           this.message_list
             .addEventListener('initrow', function(o) { ref.init_message_row(o); })
             .addEventListener('dblclick', function(o) { ref.msglist_dbl_click(o); })
-            .addEventListener('click', function(o) { ref.msglist_click(o); })
             .addEventListener('keypress', function(o) { ref.msglist_keypress(o); })
             .addEventListener('select', function(o) { ref.msglist_select(o); })
             .addEventListener('dragstart', function(o) { ref.drag_start(o); })
@@ -1851,25 +1850,6 @@ function rcube_webmail()
       this.preview_timer = setTimeout(function() { ref.msglist_get_preview(); }, list.dblclick_time);
     else if (this.env.contentframe)
       this.show_contentframe(false);
-  };
-
-  // This allow as to re-select selected message and display it in preview frame
-  this.msglist_click = function(list)
-  {
-    if (list.multi_selecting || !this.env.contentframe)
-      return;
-
-    if (!list.get_single_selection())
-      return;
-
-    var win = this.get_frame_window(this.env.contentframe);
-
-    if (win && win.location.href.indexOf(this.env.blankpage) >= 0) {
-      if (this.preview_timer)
-        clearTimeout(this.preview_timer);
-
-      this.preview_timer = setTimeout(function() { ref.msglist_get_preview(); }, list.dblclick_time);
-    }
   };
 
   this.msglist_dbl_click = function(list)


### PR DESCRIPTION
Removed 'click' event handler on messages list which was used only
to allow message re-selection. As this feature was broken since 0.9
it looks like we don't really need it. When you're in ctrl-selection
state you can easily ctrl-unselect the message.